### PR TITLE
Publish quassel-core image to Zot public registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,23 @@ Quassel is a distributed IRC client: this image runs only the **core** — the a
 
 The image is intentionally minimal: Alpine 3.24, the distro `quassel-core` package (0.14.0), a small entrypoint script, and nothing else.
 
+## Image
+
+- Registry: `registry.rich0.org/public/quassel-core` (Zot, public anonymous pull)
+- Base: Alpine 3.24
+- Ports: `4242/tcp` (client), `10113/tcp` (ident, optional)
+- Config: `/config`
+
+### Pull
+
+```bash
+docker pull registry.rich0.org/public/quassel-core:latest
+# or pin a version
+docker pull registry.rich0.org/public/quassel-core:0.15.0
+```
+
+Public pulls do not require login.
+
 ## How it works
 
 1. Container starts as user `quassel` (UID/GID **1000**).
@@ -30,7 +47,7 @@ docker run -d \
   --name quassel-core \
   -p 4242:4242 \
   -v ./config:/config \
-  ghcr.io/rich0/quassel-core:latest
+  registry.rich0.org/public/quassel-core:latest
 ```
 
 Ensure the host directory (or PVC) is writable by UID 1000:
@@ -56,7 +73,7 @@ docker run -d \
   -p 4242:4242 \
   -p 10113:10113 \
   -v ./config:/config \
-  ghcr.io/rich0/quassel-core:latest
+  registry.rich0.org/public/quassel-core:latest
 ```
 
 ### Ports
@@ -79,16 +96,19 @@ Built for non-root deployment (`runAsUser`/`fsGroup` 1000). When migrating from 
 ## Build and publish
 
 ```bash
+docker login registry.rich0.org -u ci-push -p '<password>'
 ./build-push.sh
 ```
 
 Or build locally:
 
 ```bash
-docker build -t ghcr.io/rich0/quassel-core:latest .
+docker build -t registry.rich0.org/public/quassel-core:latest .
 ```
 
-Published tags: `ghcr.io/rich0/quassel-core:0.15.0`, `:latest`.
+Pins `VERSION` / `QUASSEL_APK_VERSION` and publishes to `registry.rich0.org/public/quassel-core` (`:<version>` and `:latest`).
+
+Published tags: `registry.rich0.org/public/quassel-core:0.15.0`, `:latest`.
 
 ## License
 

--- a/build-push.sh
+++ b/build-push.sh
@@ -3,13 +3,14 @@ set -euo pipefail
 
 VERSION=0.15.0
 QUASSEL_APK_VERSION=0.14.0-r17
+IMAGE=registry.rich0.org/public/quassel-core
 
 docker build . \
   --pull \
   --build-arg VERSION=0.14.0 \
   --build-arg QUASSEL_APK_VERSION="${QUASSEL_APK_VERSION}" \
-  --tag "ghcr.io/rich0/quassel-core:${VERSION}" \
-  --tag ghcr.io/rich0/quassel-core:latest
+  --tag "${IMAGE}:${VERSION}" \
+  --tag "${IMAGE}:latest"
 
-docker push "ghcr.io/rich0/quassel-core:${VERSION}"
-docker push ghcr.io/rich0/quassel-core:latest
+docker push "${IMAGE}:${VERSION}"
+docker push "${IMAGE}:latest"


### PR DESCRIPTION
## Summary
- Point `build-push.sh` at `registry.rich0.org/public/quassel-core` (`:0.15.0` and `:latest`) instead of GHCR.
- Update README pull/run/build docs for the Zot public path and `ci-push` login.

## Follow-up
- Copy or rebuild+push the image to Zot before cutting over Flux (`k8s-flux-2` StatefulSet pin is prepared separately).
- Content-preserving copy keeps the existing digest:
  `regctl image copy ghcr.io/rich0/quassel-core:0.15.0 registry.rich0.org/public/quassel-core:0.15.0`

## Test plan
- [ ] `docker login registry.rich0.org -u ci-push` and `./build-push.sh` (or `regctl image copy` from GHCR)
- [ ] Anonymous `docker pull registry.rich0.org/public/quassel-core:0.15.0` succeeds
- [ ] README examples match the published path